### PR TITLE
Unify editable field style and highlight on hover

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Flag to disable fields that should be displayed in the UI, but aren't supposed t
 boolean
 ```
 
+Note that:
+
+- It overrides all other types. For instance, if a field enum and `x_editor_disabled` is set, then it is rendered as simple `div` instead of disabled `enum` component (dropdown).
+
 #### x_editor_always_show
 
 Flag to show fields on the UI, even if they aren't present in the record.

--- a/src/app/editor/autocomplete-input/autocomplete-input.component.html
+++ b/src/app/editor/autocomplete-input/autocomplete-input.component.html
@@ -1,10 +1,4 @@
 <div>
   <input [ngModel]="value" (ngModelChange)="onModelChange($event)" [typeahead]="dataSource" [typeaheadOptionsLimit]="autocompletionOptions.size"
-    [typeaheadOptionField]="'text'" [typeaheadWaitMs]="200" placeholder="{{placeholder}}" class="form-control">
-  <div *ngIf="isLoading === true">
-    <i class="glyphicon glyphicon-refresh ng-hide" style=""></i>
-  </div>
-  <div *ngIf="hasNoResult === true" class="" style="">
-    <i class="glyphicon glyphicon-remove"></i> Nothing found
-  </div>
+    [typeaheadOptionField]="'text'" [typeaheadWaitMs]="200" placeholder="{{placeholder}}">
 </div>

--- a/src/app/editor/primitive-field/primitive-field.component.html
+++ b/src/app/editor/primitive-field/primitive-field.component.html
@@ -1,23 +1,28 @@
 <div [ngSwitch]="valueType">
-  <div>
+  <div class="editable-field-container"> 
     <div *ngSwitchCase="'string'">
-      <textarea rows="1" [ngModel]="value" (ngModelChange)="onModelChange($event)" placeholder="{{schema.title}}" disabled="{{schema.x_editor_disabled}}"></textarea>
+      <textarea rows="1" [ngModel]="value" (ngModelChange)="onModelChange($event)" placeholder="{{schema.title}}"></textarea>
     </div>
     <div *ngSwitchCase="'enum'">
       <!-- TODO: set placeholder -->
-      <searchable-dropdown [value]="value" [items]="schema.enum" (onSelect)="onModelChange($event)" [disabled]="schema.x_editor_disabled"></searchable-dropdown>
+      <searchable-dropdown [value]="value" [items]="schema.enum" (onSelect)="onModelChange($event)"></searchable-dropdown>
     </div>
     <div *ngSwitchCase="'autocomplete'">
       <autocomplete-input [value]="value"  [autocompletionOptions]="schema.x_editor_autocomplete" (onValueChange)="onModelChange($event)" [placeholder]="schema.title"></autocomplete-input>
     </div>
     <div *ngSwitchCase="'number'">
-      <input type="number" class="form-control" [ngModel]="value" (ngModelChange)="onModelChange($event)" placeholder="{{schema.title}}" disabled="{{schema.x_editor_disabled}}">
+      <input type="number" [ngModel]="value" (ngModelChange)="onModelChange($event)" placeholder="{{schema.title}}">
     </div>
     <div *ngSwitchCase="'boolean'">
-      <input type="checkbox" [ngModel]="value" (ngModelChange)="onModelChange($event)" placeholder="{{schema.title}}" disabled="{{schema.x_editor_disabled}}">
+      <input type="checkbox" [ngModel]="value" (ngModelChange)="onModelChange($event)" placeholder="{{schema.title}}">
     </div>
     <div *ngSwitchDefault>
       ## Not recognized type: {{valueType}}
+    </div>
+  </div>
+  <div>
+    <div *ngSwitchCase="'disabled'">
+      {{value}}
     </div>
   </div>
 </div>

--- a/src/app/editor/primitive-field/primitive-field.component.scss
+++ b/src/app/editor/primitive-field/primitive-field.component.scss
@@ -1,4 +1,5 @@
-textarea {
+div.editable-field-container textarea,
+div.editable-field-container input {
     width: 50%;
     padding: 3px;
     transition: all 0.5s ease;
@@ -13,6 +14,10 @@ textarea {
     -webkit-box-sizing: border-box; // For Safari
 }
 
-textarea:focus {
+div.editable-field-container textarea:focus {
     height: 6em;
+}
+
+div.editable-field-container:hover {
+    background: #ffa;
 }

--- a/src/app/editor/primitive-field/primitive-field.component.ts
+++ b/src/app/editor/primitive-field/primitive-field.component.ts
@@ -20,7 +20,7 @@
  * as an Intergovernmental Organization or submit itself to any jurisdiction.
 */
 
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Component, Input, Output, EventEmitter, ViewEncapsulation } from '@angular/core';
 
 import { AutocompleteInputComponent } from '../autocomplete-input';
 import { SearchableDropdownComponent } from '../searchable-dropdown';
@@ -29,6 +29,7 @@ import { SchemaValidationService } from '../shared/services';
 
 @Component({
   selector: 'primitive-field',
+  encapsulation: ViewEncapsulation.None,
   directives: [AutocompleteInputComponent, SearchableDropdownComponent],
   providers: [SchemaValidationService],
   styles: [
@@ -62,10 +63,12 @@ export class PrimitiveFieldComponent {
   }
 
   get valueType(): string {
-    if (this.schema['enum']) {
-      return 'enum';
+    if (this.schema['x_editor_disabled']) {
+      return 'disabled';
     } else if (this.schema['x_editor_autocomplete']) {
       return 'autocomplete';
+    } else if (this.schema['enum']) {
+      return 'enum';
     }
     // integer, string or boolean
     return typeof this.value;

--- a/src/app/editor/searchable-dropdown/searchable-dropdown.component.html
+++ b/src/app/editor/searchable-dropdown/searchable-dropdown.component.html
@@ -1,5 +1,5 @@
 <div class="btn-group" dropdown keyboardNav="true" (onToggle)="onToggle($event)">
-  <input class="form-control" id="simple-btn-keyboard-nav" placeholder="{{value}}" [ngModel]="prefix" (ngModelChange)="onPrefixChange($event)" disabled="{{disabled}}" dropdownToggle>
+  <input id="simple-btn-keyboard-nav" placeholder="{{value}}" [ngModel]="prefix" (ngModelChange)="onPrefixChange($event)" dropdownToggle>
   <ul class="dropdown-menu" role="menu" aria-labelledby="simple-btn-keyboard-nav">
     <li *ngFor="let item of items | filterByPrefix:prefix" role="menuitem">
       <a class="dropdown-item" (click)="onItemClick(item)">{{item}}</a>

--- a/src/app/editor/searchable-dropdown/searchable-dropdown.component.ts
+++ b/src/app/editor/searchable-dropdown/searchable-dropdown.component.ts
@@ -39,7 +39,6 @@ export class SearchableDropdownComponent  {
 
   @Input() items: Array<string>;
   @Input() value: string;
-  @Input() disabled: boolean;
   prefix: string = '';
 
   @Output() onSelect: EventEmitter<string> = new EventEmitter<string>();


### PR DESCRIPTION
* Unify style of editable field types.

* Highlight editable fields on mousehover.

* Refactor `x_editor_disabled` logic.

* Update docs for `x_editor_disabled`.

GIF:

![highlight-thing](https://cloud.githubusercontent.com/assets/4868667/17294488/7843ea22-57f7-11e6-959c-df55bb083c2a.gif)


In gif, `_scheme` for `field_categories` and `id` for `oai_pmh` are disabled by `x_editor_disabled` setting.