### PR TITLE
Improve searchable-dropdown for enums (fix #58).

### DIFF
--- a/src/app/editor/primitive-field/primitive-field.component.html
+++ b/src/app/editor/primitive-field/primitive-field.component.html
@@ -5,7 +5,7 @@
     </div>
     <div *ngSwitchCase="'enum'">
       <!-- TODO: set placeholder -->
-      <searchable-dropdown [value]="value" [items]="schema.enum" (onSelect)="onModelChange($event)"></searchable-dropdown>
+      <searchable-dropdown [value]="value" [items]="schema.enum" [shortcutMap]="schema.x_editor_enum_shortcut_map" (onSelect)="onModelChange($event)"></searchable-dropdown>
     </div>
     <div *ngSwitchCase="'autocomplete'">
       <autocomplete-input [value]="value"  [autocompletionOptions]="schema.x_editor_autocomplete" (onValueChange)="onModelChange($event)" [placeholder]="schema.title"></autocomplete-input>

--- a/src/app/editor/searchable-dropdown/searchable-dropdown.component.html
+++ b/src/app/editor/searchable-dropdown/searchable-dropdown.component.html
@@ -1,8 +1,9 @@
-<div class="btn-group" dropdown keyboardNav="true" (onToggle)="onToggle($event)">
-  <input id="simple-btn-keyboard-nav" placeholder="{{value}}" [ngModel]="prefix" (ngModelChange)="onPrefixChange($event)" dropdownToggle>
-  <ul class="dropdown-menu" role="menu" aria-labelledby="simple-btn-keyboard-nav">
+<div class="btn-group" dropdown keyboardNav="true" [(isOpen)]="status.isOpen">
+  <input id="simple-btn-keyboard-nav" placeholder="{{value}}" [ngModel]="prefix" (ngModelChange)="onPrefixChange($event)" (keypress)="onKeypress($event.key)" dropdownToggle>
+  <ul class="dropdown-menu" dropdownMenu role="menu" aria-labelledby="simple-btn-keyboard-nav">
     <li *ngFor="let item of items | filterByPrefix:prefix" role="menuitem">
-      <a class="dropdown-item" (click)="onItemClick(item)">{{item}}</a>
+      <!-- href is needed for keyboard navigation -->
+      <a class="dropdown-item" href="javascript:void(0)" (click)="onItemClick(item)">{{item}}</a>
     </li>
   </ul>
 </div>

--- a/src/app/editor/searchable-dropdown/searchable-dropdown.component.scss
+++ b/src/app/editor/searchable-dropdown/searchable-dropdown.component.scss
@@ -15,3 +15,7 @@ $placeholder-color: #000;
 :-ms-input-placeholder { /* Internet Explorer 10-11 */
    color: $placeholder-color;
 }
+
+div.btn-group {
+    width: 100%;
+}

--- a/src/app/editor/searchable-dropdown/searchable-dropdown.component.ts
+++ b/src/app/editor/searchable-dropdown/searchable-dropdown.component.ts
@@ -35,11 +35,13 @@ import { FilterByPrefixPipe } from '../shared/pipes';
   ],
   template: require('./searchable-dropdown.component.html')
 })
-export class SearchableDropdownComponent  {
+export class SearchableDropdownComponent {
 
   @Input() items: Array<string>;
+  @Input() shortcutMap: Object;
   @Input() value: string;
   prefix: string = '';
+  status: { isOpen: boolean } = { isOpen: false };
 
   @Output() onSelect: EventEmitter<string> = new EventEmitter<string>();
 
@@ -47,15 +49,19 @@ export class SearchableDropdownComponent  {
     this.prefix = prefix;
   }
 
-  onToggle(isOpen: boolean) {
-    if (!isOpen) {
-      this.prefix = '';
-    }
-  }
-
   onItemClick(item: string) {
     this.value = item;
     this.onSelect.emit(item);
+  }
+
+  onKeypress(key: string) {
+    if (key === 'Enter') {
+      this.status.isOpen = false;
+      if (this.shortcutMap && this.shortcutMap[this.prefix]) {
+        this.onItemClick(this.shortcutMap[this.prefix]);
+      }
+      this.prefix = '';
+    }
   }
 
 }

--- a/src/app/editor/table-list-field/table-list-field.component.scss
+++ b/src/app/editor/table-list-field/table-list-field.component.scss
@@ -5,15 +5,16 @@ table.editable-inner-table {
     background-color: $table-editable-rows-background;
   }
 
-  td {
-    padding: 0px !important;
-  }
-
   thead > tr > th {
     border-bottom: 0px;
   }
 
   div.list-holder {
     padding: 3px;
+  }
+
+  td {
+    padding: 0 0 0 1px !important;
+    vertical-align: middle !important;
   }
 }

--- a/src/assets/mock-data/hep.json
+++ b/src/assets/mock-data/hep.json
@@ -536,6 +536,12 @@
             "x_editor_disabled": true
           },
           "term": {
+            "x_editor_enum_shortcut_map": {
+              "acc": "Accelerators",
+              "ast": "Astrophysics",
+              "eh": "Experiment-HEP",
+              "l": "Lattice"
+            },
             "enum": [
               "Accelerators",
               "Astrophysics",


### PR DESCRIPTION
* Fix style of searchable-dropdown to fit parent width.

* Implement keyboard navigation for searchable dropdown.

* Add x_editor_enum_shortcut_map extension.

* Implement shortcut logic for searchable dropdown.

* Add x_editor_enum_shortcut_map to mock schema for testing.


### GIF

![enum-dropwdown](https://cloud.githubusercontent.com/assets/4868667/17729831/5289a1de-6466-11e6-832f-9b524b0b8d35.gif)

GIF shows keyboard navigation then the shortcuts `l` to `Lattice`,  `acc` to `Accelerators`.
