### PR TITLE
Implement context menu for record nav (fix #65)

### DIFF
--- a/src/app/editor/complex-list-field/complex-list-field.component.html
+++ b/src/app/editor/complex-list-field/complex-list-field.component.html
@@ -1,7 +1,7 @@
-<div>
+<div [id]="path">
   <div>
     <table class="table table-bordered">
-      <tbody *ngFor="let value of values; let i = index; trackBy:trackByFunction">
+      <tbody *ngFor="let value of values; let i = index; trackBy:trackByFunction" [id]="path + '.' + i">
         <tr *ngFor="let row of value | mapToSortedIterable:schema.items.properties; trackBy:trackByFunction">
           <td class="label-holder">
             <div>

--- a/src/app/editor/editor.component.html
+++ b/src/app/editor/editor.component.html
@@ -34,7 +34,7 @@
     </div>
     <div class="right-side-container">
         <div>
-            <h4>MENU will be here</h4>
+            <tree-menu [record]="record" [schema]="schema"></tree-menu>
         </div>
         <div>
             <previewer [previews]="previews"> </previewer>

--- a/src/app/editor/editor.component.scss
+++ b/src/app/editor/editor.component.scss
@@ -105,3 +105,7 @@ div.right-side-container {
   padding-left: $container-padding;
   border-left: 2px solid lightgray;
 }
+
+.flash {
+  border: 2px solid yellow;
+}

--- a/src/app/editor/editor.component.ts
+++ b/src/app/editor/editor.component.ts
@@ -30,6 +30,7 @@ import { PreviewerComponent, Preview } from './previewer';
 import { PrimitiveListFieldComponent } from './primitive-list-field';
 import { PrimitiveFieldComponent } from './primitive-field';
 import { TableListFieldComponent } from './table-list-field';
+import { TreeMenuComponent } from './tree-menu';
 
 import { MapToSortedIterablePipe, UnderscoreToSpacePipe } from './shared/pipes';
 
@@ -50,6 +51,7 @@ import {
     PrimitiveListFieldComponent,
     PrimitiveFieldComponent,
     TableListFieldComponent,
+    TreeMenuComponent
   ],
   pipes: [MapToSortedIterablePipe, UnderscoreToSpacePipe],
   providers: [

--- a/src/app/editor/object-field/object-field.component.html
+++ b/src/app/editor/object-field/object-field.component.html
@@ -1,4 +1,4 @@
-<div>
+<div [id]="path">
   <table class="table table-bordered">
     <tr *ngFor="let row of value | mapToSortedIterable:schema.properties; trackBy:trackByFunction">
       <td>

--- a/src/app/editor/primitive-field/primitive-field.component.html
+++ b/src/app/editor/primitive-field/primitive-field.component.html
@@ -1,4 +1,4 @@
-<div [ngSwitch]="valueType" id="{{path}}">
+<div [ngSwitch]="valueType" [id]="path">
   <div class="editable-field-container" [ngClass]="errorNgClass" [tooltipHtml]="errors | errorsToMessagesHtml" tooltipTrigger="mouseenter" [tooltipEnable]="isErrorTooltipEnabled">
     <div *ngSwitchCase="'string'">
       <textarea rows="1" [ngModel]="value" (ngModelChange)="onModelChange($event)" placeholder="{{schema.title}}"></textarea>

--- a/src/app/editor/primitive-field/primitive-field.component.scss
+++ b/src/app/editor/primitive-field/primitive-field.component.scss
@@ -6,6 +6,7 @@ div.editable-field-container input {
     resize: none;
     border: none;
     background-color: transparent;
+    display: inline-block;
     
     // Fill parent's width 
     width:100%;

--- a/src/app/editor/primitive-list-field/primitive-list-field.component.html
+++ b/src/app/editor/primitive-list-field/primitive-list-field.component.html
@@ -1,7 +1,7 @@
-<div>
+<div [id]="path">
   <div class="wide">
     <table class="table table-bordered">
-      <tr *ngFor="let value of values; let i = index; trackBy:trackByFunction">
+      <tr *ngFor="let value of values; let i = index; trackBy:trackByFunction" [id]="path + '.' + i">
         <td>
           <primitive-field [value]="values[i]" (onValueChange)="onValueChange($event, i)" [schema]="schema.items" [path]="getValuePath(i)"></primitive-field>
         </td>

--- a/src/app/editor/shared/services/dom-util.service.ts
+++ b/src/app/editor/shared/services/dom-util.service.ts
@@ -1,0 +1,50 @@
+/*
+ * This file is part of record-editor.
+ * Copyright (C) 2016 CERN.
+ *
+ * record-editor is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * record-editor is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with record-editor; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+ * In applying this license, CERN does not
+ * waive the privileges and immunities granted to it by virtue of its status
+ * as an Intergovernmental Organization or submit itself to any jurisdiction.
+*/
+
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class DomUtilService {
+
+  focusAndSelectFirstInputChildById(id: string) {
+    let el = document.getElementById(id);
+    if (el) {
+      let firstInput = el.querySelectorAll('input, textarea').item(0) as HTMLInputElement;
+      if (firstInput) {
+        firstInput.focus();
+        firstInput.select();
+        setTimeout(() => console.log(document.activeElement), 2000);
+      }
+    }
+  }
+
+  flashElementById(id: string) {
+    let el = document.getElementById(id);
+    if (el) {
+      // .flash is defined editor.component.scss, {border: 2px solid yellow;}
+      el.classList.add('flash');
+      setTimeout(() => {
+        el.classList.remove('flash');
+      }, 500);
+    }
+  }
+}

--- a/src/app/editor/shared/services/index.ts
+++ b/src/app/editor/shared/services/index.ts
@@ -1,5 +1,6 @@
 export { AppGlobalsService } from './app-globals.service';
 export { ComponentTypeService } from './component-type.service';
+export { DomUtilService } from './dom-util.service';
 export { EmptyValueService } from './empty-value.service';
 export { JsonUtilService } from './json-util.service';
 export { RecordFixerService } from './record-fixer.service';

--- a/src/app/editor/table-list-field/table-list-field.component.html
+++ b/src/app/editor/table-list-field/table-list-field.component.html
@@ -1,4 +1,4 @@
-<div>
+<div [id]="path">
   <div>
     <table class="table table-bordered editable-inner-table">
       <thead class="thead-inverse">
@@ -13,7 +13,7 @@
 
         </tr>
       </thead>
-      <tr *ngFor="let row of values; let i = index; trackBy:trackByFunction">
+      <tr *ngFor="let row of values; let i = index; trackBy:trackByFunction" [id]="path + '.' + i">
         <!-- Element value -->
         <td *ngFor="let column of row | mapToSortedIterable:schema.items.properties; trackBy:trackByFunction">
           <div [ngSwitch]="getFieldType(column.key)">

--- a/src/app/editor/tree-menu/index.ts
+++ b/src/app/editor/tree-menu/index.ts
@@ -1,0 +1,1 @@
+export { TreeMenuComponent } from './tree-menu.component';

--- a/src/app/editor/tree-menu/tree-menu-item.component.html
+++ b/src/app/editor/tree-menu/tree-menu-item.component.html
@@ -1,0 +1,18 @@
+<div>
+  <a [href]="href" (click)="toggle($event)">{{label}}</a>
+  <a *ngIf="isCollapsable" [hidden]="isCollapsed" (click)="collapse()"> [x]</a>
+  <div [ngSwitch]="schema.type" [hidden]="isCollapsed">
+    <ul>
+      <div *ngSwitchCase="'object'">
+        <li *ngFor="let pair of value | mapToSortedIterable:schema.properties; trackBy:trackByFunction">
+          <tree-menu-item [label]="pair.key" [value]="pair.value" [schema]="schema.properties[pair.key]" [path]="path + '.' + pair.key"></tree-menu-item>
+        </li>
+      </div>
+      <div *ngSwitchCase="'array'">
+        <li *ngFor="let element of value; let i = index; trackBy:trackByFunction">
+          <tree-menu-item [label]="i" [value]="element" [schema]="schema.items" [path]="path + '.' + i"></tree-menu-item>
+        </li>
+      </div>
+    </ul>
+  </div>
+</div>

--- a/src/app/editor/tree-menu/tree-menu-item.component.ts
+++ b/src/app/editor/tree-menu/tree-menu-item.component.ts
@@ -1,0 +1,76 @@
+/*
+ * This file is part of record-editor.
+ * Copyright (C) 2016 CERN.
+ *
+ * record-editor is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * record-editor is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with record-editor; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+ * In applying this license, CERN does not
+ * waive the privileges and immunities granted to it by virtue of its status
+ * as an Intergovernmental Organization or submit itself to any jurisdiction.
+*/
+
+import { Component, Input, forwardRef } from '@angular/core';
+
+import { AbstractTrackerComponent } from '../abstract-tracker';
+
+import { MapToSortedIterablePipe } from '../shared/pipes';
+
+import { DomUtilService } from '../shared/services'
+import { WindowHrefService } from './window-href.service';
+ 
+@Component({
+  selector: 'tree-menu-item',
+  directives: [forwardRef(() => TreeMenuItemComponent)],
+  pipes: [MapToSortedIterablePipe],
+  styles: [
+    require('./tree-menu-item.component.scss')
+  ],
+  template: require('./tree-menu-item.component.html'),
+})
+export class TreeMenuItemComponent extends AbstractTrackerComponent {
+
+  @Input() label: string;
+  @Input() value: any;
+  @Input() schema: Object;
+  @Input() path: string;
+  private isCollapsed: boolean = true;
+  private href: string; 
+
+  constructor(private windowHrefService: WindowHrefService,
+    private domUtilService: DomUtilService) {
+    super();
+  }
+
+  ngOnInit() {
+    this.href = `${this.windowHrefService.getHrefWithoutHash()}#${this.path}`;
+  }
+
+  toggle(event: Event) {
+    // fix to trigger :focus css after focusAndSelectFirstInputChildById called.
+    event.preventDefault(); 
+    
+    this.isCollapsed = !this.isCollapsed;
+    this.domUtilService.focusAndSelectFirstInputChildById(this.path);
+    this.domUtilService.flashElementById(this.path);
+  }
+
+  collapse() {
+    this.isCollapsed = true;
+  }
+
+  get isCollapsable(): boolean {
+    let schemaType = this.schema['type'];
+    return (schemaType === 'object' || schemaType === 'array');
+  }
+}

--- a/src/app/editor/tree-menu/tree-menu.component.html
+++ b/src/app/editor/tree-menu/tree-menu.component.html
@@ -1,0 +1,11 @@
+<div>
+  <h5>Record Navigation</h5>
+  <div class="well tree-menu-container">
+    <input class="wide" type="text" [(ngModel)]="prefixOrPath" (keypress)="onKeypress($event.key)" placeholder="Search or go">
+    <ul class="menu-item-container">
+      <li *ngFor="let pair of record | mapToSortedIterable:schema.properties; trackBy:trackByFunction" [hidden]="!filter(pair.key)">
+        <tree-menu-item [label]="pair.key" [value]="pair.value" [schema]="schema.properties[pair.key]" [path]="pair.key" [searchPrefix]="searchPrefix"></tree-menu-item>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/src/app/editor/tree-menu/tree-menu.component.scss
+++ b/src/app/editor/tree-menu/tree-menu.component.scss
@@ -1,0 +1,19 @@
+div.tree-menu-container {
+  width: 300px;
+  height: 500px;
+  padding: 8px 0;
+  overflow-x: hidden;
+  overflow-y: scroll;
+  text-align: center;
+}
+
+input.wide {
+  width: 90%;
+  padding: 2px;
+  text-align: center;
+}
+
+ul.menu-item-container {
+  text-align: left;
+  padding-top: 8px;
+}

--- a/src/app/editor/tree-menu/tree-menu.component.ts
+++ b/src/app/editor/tree-menu/tree-menu.component.ts
@@ -1,0 +1,67 @@
+/*
+ * This file is part of record-editor.
+ * Copyright (C) 2016 CERN.
+ *
+ * record-editor is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * record-editor is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with record-editor; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+ * In applying this license, CERN does not
+ * waive the privileges and immunities granted to it by virtue of its status
+ * as an Intergovernmental Organization or submit itself to any jurisdiction.
+*/
+
+import { Component, Input } from '@angular/core';
+
+
+import { AbstractTrackerComponent } from '../abstract-tracker';
+import { TreeMenuItemComponent } from './tree-menu-item.component';
+
+import { FilterByPrefixPipe, MapToSortedIterablePipe } from '../shared/pipes';
+
+import { DomUtilService } from '../shared/services'
+import { WindowHrefService } from './window-href.service.ts';
+
+@Component({
+  selector: 'tree-menu',
+  directives: [TreeMenuItemComponent],
+  pipes: [MapToSortedIterablePipe],
+  providers: [DomUtilService, WindowHrefService],
+  styles: [
+    require('./tree-menu.component.scss')
+  ],
+  template: require('./tree-menu.component.html'),
+})
+export class TreeMenuComponent extends AbstractTrackerComponent {
+
+  @Input() record: Object;
+  @Input() schema: Object;
+
+  private prefixOrPath: string = '';
+
+  constructor(private windowHrefService: WindowHrefService,
+    private domUtilService: DomUtilService) {
+    super();
+  }
+
+  filter(key: string): boolean {
+    return key.startsWith(this.prefixOrPath);
+  }
+
+  onKeypress(key: string) {
+    if (key === 'Enter') {
+      this.windowHrefService.appendHash(this.prefixOrPath);
+      this.domUtilService.focusAndSelectFirstInputChildById(this.prefixOrPath);
+      this.domUtilService.flashElementById(this.prefixOrPath);
+    }
+  }
+}

--- a/src/app/editor/tree-menu/window-href.service.ts
+++ b/src/app/editor/tree-menu/window-href.service.ts
@@ -1,0 +1,49 @@
+/*
+ * This file is part of record-editor.
+ * Copyright (C) 2016 CERN.
+ *
+ * record-editor is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * record-editor is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with record-editor; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+ * In applying this license, CERN does not
+ * waive the privileges and immunities granted to it by virtue of its status
+ * as an Intergovernmental Organization or submit itself to any jurisdiction.
+*/
+
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class WindowHrefService {
+  private static hrefWithoutHash: string;
+
+  getHrefWithoutHash(): string {
+    // check if it is already cached
+    if (!WindowHrefService.hrefWithoutHash) {
+      let href = window.location.href;
+      // check if there is an hash in href
+      let lastHashIndex = href.lastIndexOf('#');
+      if (lastHashIndex > 0) {
+        // remove hash.
+        WindowHrefService.hrefWithoutHash = href.substring(0, lastHashIndex);
+      } else {
+         WindowHrefService.hrefWithoutHash = href;
+      }
+    }
+    // return cached value
+    return WindowHrefService.hrefWithoutHash;
+  }
+
+  appendHash(hash: string) {
+    window.location.href = `${this.getHrefWithoutHash()}#${hash}`;
+  }
+}


### PR DESCRIPTION
* Implement tree-menu and tree-menu-item components.

* Implement window-href service that gets window.location.href.

* Set value path as an id to each component in order to navigate via #.

* Introduce shared dom-utils service with focus, select and flash utilities.

* Focus the first input child when navigated to a component.

* Implement shallow search for menu and navigation by typing.


### GIFS

##### You can search things, and navigate to them by `enter` if you give the exact path.
![type-tree-menu](https://cloud.githubusercontent.com/assets/4868667/17997482/1b3fa93e-6b6f-11e6-8bdf-8142a5eaf21e.gif)

##### Clicking things works too.
![click-tree-menu](https://cloud.githubusercontent.com/assets/4868667/17997486/1fa31d8a-6b6f-11e6-8d8e-049269d170a7.gif)
