### PR TITLE
cofigure experiment autocompletion and $ref templ

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -46,6 +46,28 @@ export const INSPIRE_EDITOR_CONFIG: AppConfig = {
     'external_system_numbers.items.properties.value': {
       x_editor_priority: 1
     },
+    'accelerator_experiments.items.properties.experiment': {
+      x_editor_autocomplete: {
+        url: 'http://localhost:5000/api/experiments/_suggest?experiment=',
+        path: 'experiment.0.options',
+        size: 5,
+        onCompletionSelect: (path, completion, store) => {
+          path.splice(-1, 1, 'record', '$ref');
+          store.setIn(path, completion.payload['$ref']);
+          path.splice(-2, 2, 'curated_relation');
+          store.setIn(path, true);
+        }
+      }
+    },
+    'accelerator_experiments.items.properties.record': {
+      x_editor_ref_config: {
+        template: '<span>{{(context | async)?.metadata.titles[0].title}}</span>',
+        lazy: false,
+        headers: [
+          { name: 'Accept', value: 'application/json' }
+        ]
+      }
+    },
     'hidden_notes.items.properties.value': {
       x_editor_priority: 1
     },
@@ -87,9 +109,6 @@ export const INSPIRE_EDITOR_CONFIG: AppConfig = {
     },
     'publication_info.items.properties.year': {
       x_editor_priority: 5
-    },
-    'references.items.properties.record': {
-      x_editor_hidden: true
     },
     'report_numbers.items.properties.value': {
       x_editor_priority: 1


### PR DESCRIPTION
* Adds proof-of-concept configuration for usecase when
autocompletion field controls templated $ref field.