### PR TITLE
Move karma and Travis testing to Chrome

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,11 @@ sudo: false
 
 before_script: npm run lint
 
-before_install: npm install karma-phantomjs-launcher
+before_install:
+  - npm install buffer-shims
+  - export CHROME_BIN=chromium-browser
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
 
 before_deploy: npm run build
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -7,7 +7,7 @@ module.exports = function (config) {
     frameworks: ['jasmine', 'angular-cli'],
     plugins: [
       require('karma-jasmine'),
-      process.env.TRAVIS ? require('karma-phantomjs-launcher') : require('karma-chrome-launcher'),
+      require('karma-chrome-launcher'),
       require('karma-remap-istanbul'),
       require('angular-cli/plugins/karma')
     ],
@@ -32,7 +32,21 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: process.env.TRAVIS ? ['PhantomJS'] : ['Chrome'],
-    singleRun: false
+    browsers: ['Chrome'],
+    singleRun: false,
+    customLaunchers: {
+      Chrome_travis_ci: {
+        base: 'Chrome',
+        flags: ['--no-sandbox']
+      }
+    },
+    mime: {
+      'text/x-typescript': ['ts', 'tsx']
+    },
+    client: { captureConsole: true }
   });
+
+  if (process.env.TRAVIS) {
+    config.browsers = ['Chrome_travis_ci'];
+  }
 };


### PR DESCRIPTION
* Uses only Chrome for testing both locally and on Travis. (closes #100)

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>

