### PR TITLE
add local stroge backup

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "font-awesome": "^4.7.0",
     "lodash": "4.17.2",
     "ng2-json-editor": "~0.6.0",
+    "ng2-webstorage": "^1.5.1",
     "rxjs": "^5.0.1",
     "ts-helpers": "^1.1.1",
     "zone.js": "^0.7.2"

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -4,6 +4,7 @@ import { APP_BASE_HREF } from '@angular/common';
 import { HttpModule } from '@angular/http';
 
 import { JsonEditorModule } from 'ng2-json-editor';
+import { Ng2Webstorage } from 'ng2-webstorage';
 
 import { AppComponent } from './app.component';
 import { EditorHoldingPenComponent } from './editor-holdingpen';
@@ -31,7 +32,8 @@ import { AppConfigService } from './app-config.service';
     BrowserModule,
     HttpModule,
     routing,
-    JsonEditorModule
+    JsonEditorModule,
+    Ng2Webstorage
   ],
   providers: [
     { provide: APP_BASE_HREF, useValue: '/editor' },

--- a/src/app/editor-container/editor-container.component.ts
+++ b/src/app/editor-container/editor-container.component.ts
@@ -24,7 +24,6 @@ import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
 import { ApiService } from '../shared/services';
-
 import { AppConfigService } from '../app-config.service';
 
 @Component({
@@ -47,7 +46,11 @@ export class EditorContainerComponent implements OnInit {
       .subscribe(params => {
         this.apiService.fetchRecord(params['type'], params['recid'])
           .then(record => {
-            this.record = record['metadata'];
+            // load record.metadata or record (if it is from local storage)
+            this.record = record['metadata'] || record;
+            window.onbeforeunload = () => {
+              this.apiService.saveDataLocally(this.record);
+            };
             this.config = this.appConfig.getConfigForRecord(this.record);
             return this.apiService.fetchUrl(this.record['$schema']);
           }).then(schema => {

--- a/src/app/editor-holdingpen-toolbar/editor-holdingpen-toolbar-save/editor-holdingpen-toolbar-save.component.ts
+++ b/src/app/editor-holdingpen-toolbar/editor-holdingpen-toolbar-save/editor-holdingpen-toolbar-save.component.ts
@@ -34,7 +34,7 @@ export class EditorHoldingPenToolbarSaveComponent {
   constructor(private apiService: ApiService) { }
 
   onClickSave(event: Object) {
-    this.apiService.saveWorkflowObject(this.workflowObject)
+    this.apiService.saveData(this.workflowObject)
       .subscribe(resp => {
         window.location.href = `/holdingpen/${this.workflowObject.id}`;
       });

--- a/src/app/editor-holdingpen/editor-holdingpen.component.ts
+++ b/src/app/editor-holdingpen/editor-holdingpen.component.ts
@@ -23,9 +23,9 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
-import { ApiService } from '../shared/services';
 import 'rxjs/add/operator/mergeMap';
 
+import { ApiService } from '../shared/services';
 import { AppConfigService } from '../app-config.service';
 
 @Component({
@@ -49,12 +49,17 @@ export class EditorHoldingPenComponent implements OnInit {
         this.apiService.fetchWorkflowObject(params['objectid'])
           .then(workflowObject => {
             this.workflowObject = workflowObject;
+            window.onbeforeunload = () => {
+              this.apiService.saveDataLocally(this.workflowObject);
+            };
             this.config = this.appConfig.getConfigForRecord(this.workflowObject['metadata']);
             return this.apiService.fetchUrl(this.workflowObject['metadata']['$schema']);
           }).then(schema => {
             this.schema = schema;
+
           }).catch(error => console.error(error));
       });
+
   }
 
   onRecordChange(record: Object) {

--- a/src/app/editor-toolbar/editor-toolbar-save/editor-toolbar-save.component.ts
+++ b/src/app/editor-toolbar/editor-toolbar-save/editor-toolbar-save.component.ts
@@ -54,7 +54,7 @@ export class EditorToolbarSaveComponent {
           bodyHtml: this.domSanitizer.bypassSecurityTrustHtml('<iframe id="iframe-preview"></iframe>'),
           type: 'confirm',
           onConfirm: () => {
-            this.apiService.saveRecord(this.record).subscribe({
+            this.apiService.saveData(this.record).subscribe({
               next: () => {
                 this.route.params
                   .subscribe(params => {


### PR DESCRIPTION
* Fixes #120. Saves current version of data before window/tab is
closed by the its url from where it was fetched earlier. And check
before fetching a data if it exists on local stroge. Finally clear the
data if it is save successfully.

* Refactors api.service.

## Some discussion

- Actually clearing doesn't help much since even you don't touch the record after saving remotely, it will be saved locally on window unload. It only works when you open this saved record again in another tab without closing. I'd like to know if we should keep the copy of last remotely saved data and compare it with the current one on window unload before saving the current one to local storage.

- Although it's not in the PR yet but I think we should ask if user wants to load local copy or remote when local copy exists. For this one @StellaCh might help to figure out if we want to load local by default and have a reload button for re-fetch or ask to save locally when closing the tab or ask to load local save on the start
