### PR TITLE
services: address http/https mixed content issue

### DIFF
--- a/src/app/shared/services/app-config.service.ts
+++ b/src/app/shared/services/app-config.service.ts
@@ -400,8 +400,11 @@ export class AppConfigService {
             getUrl: (record) => {
               let urls: Array<{ value: string }> = record['urls'];
               if (urls && urls.length > 0) {
-                return urls.map(url => url.value)
+                let url = urls.map(_url => _url.value)
                   .find(value => value.endsWith('.pdf'));
+                if (url !== undefined) {
+                  return url.replace('http://', '//');
+                }
               } else {
                 return undefined;
               }
@@ -413,7 +416,7 @@ export class AppConfigService {
             getUrl: (record) => {
               let ePrints: Array<{ value: string }> = record['arxiv_eprints'];
               if (ePrints && ePrints.length > 0) {
-                return `http://arxiv.org/abs/${ePrints[0].value}`;
+                return `//arxiv.org/abs/${ePrints[0].value}`;
               } else {
                 return undefined;
               }
@@ -425,7 +428,7 @@ export class AppConfigService {
             getUrl: (record) => {
               let dois: Array<{ value: string }> = record['dois'];
               if (dois && dois.length > 0) {
-                return `http://dx.doi.org/${dois[0].value}`;
+                return `//dx.doi.org/${dois[0].value}`;
               } else {
                 return undefined;
               }


### PR DESCRIPTION
* Make sure preview URLs use the same URL scheme as the page containing
  them. This avoids mixed content errors thrown by the browser.

* NOTE: For dx.doi.org requests, since a redirect is made, http is
  returned and problems in iframe still exist.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>

