### PR TITLE
move reference field split to common and #197

### DIFF
--- a/src/app/shared/services/app-config.service.spec.ts
+++ b/src/app/shared/services/app-config.service.spec.ts
@@ -32,7 +32,7 @@ describe('AppConfigService', () => {
   let service: AppConfigService;
 
   beforeEach(() => {
-    service = new AppConfigService(new CommonConfigsService(), new FieldSplitterService());
+    service = new AppConfigService(new CommonConfigsService(new FieldSplitterService()));
   });
 
   it('should get a merged config for an hep type', () => {

--- a/src/app/shared/services/app-config.service.ts
+++ b/src/app/shared/services/app-config.service.ts
@@ -6,7 +6,6 @@ import { JsonEditorConfig } from 'ng2-json-editor';
 import * as _ from 'lodash';
 
 import { CommonConfigsService } from './common-configs.service';
-import { FieldSplitterService } from './field-splitter.service';
 
 @Injectable()
 export class AppConfigService {
@@ -318,41 +317,7 @@ export class AppConfigService {
             order: ['label', 'title', 'authors', 'arxiv_eprint']
           },
           '/references/items/properties/reference/properties/misc/items': {
-            onValueChange: (path, value, jsonStore, keyStore) => {
-              let splitResult = this.fieldSplitterService.splitReferenceMisc(value);
-              // parent path, ['references', N, 'reference']
-              let parentPath = path.slice(0, -2);
-              splitResult.splits.forEach(split => {
-                // handle array insert
-                let relativePath = split.path;
-                let insertLast = relativePath.findIndex(el => el === '-');
-                if (insertLast > -1) {
-                  let valueToInsert;
-                  let sliceIndex = insertLast + 1;
-                  let insertPath = relativePath.slice(0, sliceIndex);
-                  if (sliceIndex < relativePath.length) {
-                    let afterInsertPath = relativePath.slice(sliceIndex);
-                    let stub = {};
-                    stub[afterInsertPath[afterInsertPath.length - 1]] = split.value;
-                    for (let i = afterInsertPath.length - 2; i >= 0; i--) {
-                      let temp = { [afterInsertPath[i]]: stub };
-                      stub = temp;
-                    }
-                    valueToInsert = stub;
-                  } else {
-                    valueToInsert = split.value;
-                  }
-                  let fullInsertPath = parentPath.concat(insertPath);
-                  jsonStore.addIn(fullInsertPath, valueToInsert);
-                } else {
-                  let toPath = parentPath.concat(split.path);
-                  jsonStore.setIn(toPath, split.value);
-                }
-
-              });
-              jsonStore.setIn(path, splitResult.unsplitted);
-              keyStore.buildKeysMapRecursivelyForPath(jsonStore.getIn(parentPath), parentPath);
-            }
+            onValueChange: this.commonConfigsService.splitPrimitiveReferenceField
           },
           '/urls/items': {
             alwaysShow: ['value', 'description']
@@ -423,7 +388,7 @@ export class AppConfigService {
                 let url = urls.map(_url => _url.value)
                   .find(value => value.endsWith('.pdf'));
                 if (url !== undefined) {
-                  return url.replace('http://', '//') + '#zoom=100' ;
+                  return url.replace('http://', '//') + '#zoom=100';
                 }
               } else {
                 return undefined;
@@ -472,8 +437,7 @@ export class AppConfigService {
 
   onConfigChange = new ReplaySubject<EditorConfig>();
 
-  constructor(private commonConfigsService: CommonConfigsService,
-    private fieldSplitterService: FieldSplitterService) { }
+  constructor(private commonConfigsService: CommonConfigsService) { }
 
   apiUrl(pidType: string, pidValue: string): string {
     return `${environment.baseUrl}/api/${pidType}/${pidValue}/db`;


### PR DESCRIPTION
* Moves references field splitting logic to common config so that we
can have multiple reference fields sharing it.

* Removes parent array, if the field is completely splitted and it's
the only remaining element in its parent

