### PR TITLE
show errors on debug mode

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -25,7 +25,11 @@ Raven
 
 export class RavenErrorHandler implements ErrorHandler {
   handleError(error: any) {
-    Raven.captureException(error);
+    if (environment.production) {
+      Raven.captureException(error);
+    } else {
+      throw error;
+    }
   }
 }
 


### PR DESCRIPTION
* Errors weren't showing because of global angular ErrorHandler setup
for sentry. Now errors are thrown on production === false.

