### PR TITLE
holdingpen: try to go back if callback succesful

### DIFF
--- a/src/app/holdingpen-editor/holdingpen-save-button/holdingpen-save-button.component.ts
+++ b/src/app/holdingpen-editor/holdingpen-save-button/holdingpen-save-button.component.ts
@@ -95,7 +95,10 @@ export class HoldingpenSaveButtonComponent extends SubscriberComponent implement
     this.apiService.saveWorkflowObjectWithCallbackUrl(this.workflowObject, this.callbackUrl)
       .do(() => this.domUtilsService.unregisterBeforeUnloadPrompt())
       .subscribe(() => {
-        window.open(`/holdingpen/${this.workflowObject}`);
+        const referrer = document.referrer;
+        const origin = window.location.origin;
+        const redirectUrl = referrer.startsWith(origin) ? referrer : `/holdingpen/${this.workflowObject.id}`;
+        window.location.href = redirectUrl;
       }, (error: ApiError<WorkflowSaveErrorBody>) => {
         if (error.status === 400 && error.body.error_code === 'VALIDATION_ERROR') {
           this.jsonBeingEdited$.next(error.body.workflow);


### PR DESCRIPTION
* Go back if previous page is inspire, go to detail page of edited
workflow object if it is not.

