### PR TITLE
fix hep configs

### DIFF
--- a/src/app/shared/config/hep/index.ts
+++ b/src/app/shared/config/hep/index.ts
@@ -20,20 +20,19 @@
  * as an Intergovernmental Organization or submit itself to any jurisdiction.
  */
 
-import * as _ from 'lodash';
-
 import { coreHep } from './core.config';
 import { thesisHep } from './thesis.config';
 import { bookHep } from './book.config';
 import { bookChapterHep } from './book-chapter.config';
 import { proceedingsHep } from './proceedings.config';
 import { conferencePaperHep } from './conference-paper.config';
+import { immutableMergeWithConcattingArrays } from './utils';
 
 export const hep = coreHep;
-export const thesis = _.merge(coreHep, thesisHep);
-export const book = _.merge(coreHep, bookHep);
-export const bookChapter = _.merge(coreHep, bookChapterHep);
-export const proceedings = _.merge(coreHep, proceedingsHep);
-export const conferencePaper = _.merge(coreHep, conferencePaperHep);
+export const thesis = immutableMergeWithConcattingArrays(coreHep, thesisHep);
+export const book = immutableMergeWithConcattingArrays(coreHep, bookHep);
+export const bookChapter = immutableMergeWithConcattingArrays(coreHep, bookChapterHep);
+export const proceedings = immutableMergeWithConcattingArrays(coreHep, proceedingsHep);
+export const conferencePaper = immutableMergeWithConcattingArrays(coreHep, conferencePaperHep);
 
 export { onDocumentTypeChange } from './utils';

--- a/src/app/shared/config/hep/utils.spec.ts
+++ b/src/app/shared/config/hep/utils.spec.ts
@@ -1,0 +1,58 @@
+/*
+ * This file is part of record-editor.
+ * Copyright (C) 2018 CERN.
+ *
+ * record-editor is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * record-editor is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with record-editor; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+ * In applying this license, CERN does not
+ * waive the privileges and immunities granted to it by virtue of its status
+ * as an Intergovernmental Organization or submit itself to any jurisdiction.
+*/
+
+import { immutableMergeWithConcattingArrays } from './utils';
+
+describe('Utils', () => {
+  describe('immutableMergeWithConcattingArrays', () => {
+    it('concats arrays during merging', () => {
+      const obj1 = { array: [1] };
+      const obj2 = { array: [2, 3] };
+      const expected = { array: [1, 2, 3] };
+      const result = immutableMergeWithConcattingArrays(obj1, obj2);
+      expect(result).toEqual(expected);
+    });
+
+    it('overrides if only one of them is array', () => {
+      const obj1 = { foo: [1], another: 'value' };
+      const obj2 = { foo: 'bar', another: [2] };
+      const expected = { foo: 'bar', another: [2] };
+      const result = immutableMergeWithConcattingArrays(obj1, obj2);
+      expect(result).toEqual(expected);
+    });
+
+    it('merges simple objects', () => {
+      const obj1 = { a: 'a1', b: 'b1' };
+      const obj2 = { b: 'b2', c: 'c2' };
+      const expected = { a: 'a1', b: 'b2', c: 'c2' };
+      const result = immutableMergeWithConcattingArrays(obj1, obj2);
+      expect(result).toEqual(expected);
+    });
+
+    it('clones destination before merging', () => {
+      const obj1 = { a: 'a1' };
+      const obj2 = { b: 'b2' };
+      const result = immutableMergeWithConcattingArrays(obj1, obj2);
+      expect(result).not.toBe(obj1);
+    });
+  });
+});

--- a/src/app/shared/config/hep/utils.ts
+++ b/src/app/shared/config/hep/utils.ts
@@ -21,5 +21,15 @@
  */
 
 import { ReplaySubject } from 'rxjs/ReplaySubject';
+import { cloneDeep, mergeWith } from 'lodash';
 
 export const onDocumentTypeChange = new ReplaySubject<string>();
+
+export function immutableMergeWithConcattingArrays(destObject: object, ...sources: object[]): object {
+  const clonedDestObject = cloneDeep(destObject);
+  return mergeWith(clonedDestObject, ...sources, (objValue, srcValue) => {
+    if (Array.isArray(objValue) && Array.isArray(srcValue)) {
+      return objValue.concat(srcValue);
+    }
+  });
+}


### PR DESCRIPTION
Since lodash merge is modifiying the destination object at the end all
configurations were same.

Fix also includes array concatanation during merge so that order,
alwaysShow (array configs) inherited correctly from core hep config.

