### PR TITLE
bump ng2-json-editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "font-awesome": "^4.7.0",
     "immutable": "^3.8.1",
     "lodash": "4.17.2",
-    "ng2-json-editor": "^0.25.3",
+    "ng2-json-editor": "^0.25.13",
     "ngx-bootstrap": "2.0.0-beta.7",
     "ngx-toastr": "^6.1.4",
     "raven-js": "3.27.0",


### PR DESCRIPTION
This is to force travis because travis deployment picks up older,
cached version

